### PR TITLE
Add Docker container engine provisioner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     steps:

--- a/Devantler.ContainerEngineProvisioner.Core/Devantler.ContainerEngineProvisioner.Core.csproj
+++ b/Devantler.ContainerEngineProvisioner.Core/Devantler.ContainerEngineProvisioner.Core.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>preview-all</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/Devantler.ContainerEngineProvisioner.Core/IContainerEngineProvisioner.cs
+++ b/Devantler.ContainerEngineProvisioner.Core/IContainerEngineProvisioner.cs
@@ -1,0 +1,41 @@
+﻿namespace Devantler.ContainerEngineProvisioner.Core;
+
+/// <summary>
+/// A container engine provisioner capable of modifying resources in a container engine.
+/// </summary>
+public interface IContainerEngineProvisioner
+{
+  /// <summary>
+  /// Checks if the container engine is ready.
+  /// </summary>
+  /// <param name="token"></param>
+  Task<bool> CheckReadyAsync(CancellationToken token);
+
+  /// <summary>
+  /// Creates a registry in the container engine.
+  /// </summary>
+  /// <param name="name"></param>
+  /// <param name="port"></param>
+  /// <param name="token"></param>
+  /// <param name="proxyUrl"></param>
+  Task CreateRegistryAsync(string name, int port, CancellationToken token, Uri? proxyUrl = null);
+
+  /// <summary>
+  /// Deletes a registry in the container engine.
+  /// </summary>
+  /// <param name="name"></param>
+  /// <param name="token"></param>
+  Task DeleteRegistryAsync(string name, CancellationToken token);
+
+  /// <summary>
+  /// Gets the container ID of a container in the container engine.
+  /// </summary>
+  /// <param name="name"></param>
+  /// <param name="token"></param>
+  Task<string> GetContainerIdAsync(string name, CancellationToken token);
+
+  /// <summary>
+  /// Checks that the container exists in the container engine.
+  /// </summary>
+  Task<bool> CheckContainerExistsAsync(string name, CancellationToken token);
+}

--- a/Devantler.ContainerEngineProvisioner.Docker.Tests/Devantler.ContainerEngineProvisioner.Docker.Tests.csproj
+++ b/Devantler.ContainerEngineProvisioner.Docker.Tests/Devantler.ContainerEngineProvisioner.Docker.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>preview-all</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+    <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Devantler.ContainerEngineProvisioner.Docker\Devantler.ContainerEngineProvisioner.Docker.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CheckReadyAsyncTests.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CheckReadyAsyncTests.cs
@@ -1,0 +1,23 @@
+namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
+
+/// <summary>
+/// Unit tests for <see cref="DockerProvisioner.CheckReadyAsync(CancellationToken)"/>.
+/// </summary>
+public class CheckReadyAsyncTests
+{
+  readonly DockerProvisioner _provisioner = new();
+
+  /// <summary>
+  /// Tests whether the the boolean value returned by the method is true when the Docker engine is ready.
+  /// </summary>
+  /// <returns></returns>
+  [Fact]
+  public async Task CheckReadyAsync_ReturnsTrue_WhenDockerIsReady()
+  {
+    // Act
+    bool containerEngineIsReady = await _provisioner.CheckReadyAsync(CancellationToken.None);
+
+    // Assert
+    Assert.True(containerEngineIsReady);
+  }
+}

--- a/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
@@ -1,0 +1,78 @@
+namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
+
+/// <summary>
+/// Unit tests for <see cref="DockerProvisioner.CreateRegistryAsync(string, int, CancellationToken, Uri?)"/> and <see cref="DockerProvisioner.DeleteRegistryAsync(string, CancellationToken)"/>.
+/// </summary>
+public class CreateRegistryAsyncTests
+{
+  readonly DockerProvisioner _provisioner = new();
+
+  /// <summary>
+  /// Tests whether the registry is created when it does not exist.
+  /// </summary>
+  /// <returns></returns>
+  [Fact]
+  public async Task CreateRegistryAsync_RegistryDoesNotExist_CreatesRegistry()
+  {
+    // Arrange
+    string registryName = "new_registry";
+    int port = 5999;
+    var token = CancellationToken.None;
+
+    // Act
+    await _provisioner.CreateRegistryAsync(registryName, port, token);
+
+    // Assert
+    bool registryExists = await _provisioner.CheckContainerExistsAsync(registryName, token);
+    Assert.True(registryExists);
+
+    // Cleanup
+    await _provisioner.DeleteRegistryAsync(registryName, token);
+  }
+
+  /// <summary>
+  /// Tests whether the registry is not created when it already exists.
+  /// </summary>
+  [Fact]
+  public async Task CreateRegistryAsync_RegistryExists_DoesNotCreateRegistry()
+  {
+    // Arrange
+    string registryName = "new_registry";
+    int port = 5999;
+    var token = CancellationToken.None;
+
+    // Act
+    await _provisioner.CreateRegistryAsync(registryName, port, token);
+    await _provisioner.CreateRegistryAsync(registryName, port, token);
+
+    // Assert
+    bool registry1Exists = await _provisioner.CheckContainerExistsAsync(registryName, token);
+    await _provisioner.DeleteRegistryAsync(registryName, token);
+    Assert.True(registry1Exists);
+    bool registry2Exists = await _provisioner.CheckContainerExistsAsync(registryName, token);
+    Assert.False(registry2Exists);
+  }
+
+  /// <summary>
+  /// Tests whether a pull-through registry is created when a proxy URL is provided.
+  /// </summary>
+  [Fact]
+  public async Task CreateRegistryAsync_ProxyUrlProvided_CreatesPullThroughRegistry()
+  {
+    // Arrange
+    string registryName = "new_registry";
+    int port = 5999;
+    var token = CancellationToken.None;
+    Uri proxyUrl = new("http://proxy:8080");
+
+    // Act
+    await _provisioner.CreateRegistryAsync(registryName, port, token, proxyUrl);
+
+    // Assert
+    bool registryExists = await _provisioner.CheckContainerExistsAsync(registryName, token);
+    Assert.True(registryExists);
+
+    // Cleanup
+    await _provisioner.DeleteRegistryAsync(registryName, token);
+  }
+}

--- a/Devantler.ContainerEngineProvisioner.Docker/Devantler.ContainerEngineProvisioner.Docker.csproj
+++ b/Devantler.ContainerEngineProvisioner.Docker/Devantler.ContainerEngineProvisioner.Docker.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>preview-all</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Docker.DotNet" Version="3.125.15" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Devantler.ContainerEngineProvisioner.Core\Devantler.ContainerEngineProvisioner.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
@@ -1,0 +1,149 @@
+﻿using Devantler.ContainerEngineProvisioner.Core;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+
+namespace Devantler.ContainerEngineProvisioner.Docker;
+
+/// <summary>
+/// A provisioner for Docker.
+/// </summary>
+public sealed class DockerProvisioner : IContainerEngineProvisioner
+{
+  readonly DockerClient _dockerClient;
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="DockerProvisioner"/> class.
+  /// </summary>
+  public DockerProvisioner()
+  {
+    string? dockerHost = Environment.GetEnvironmentVariable("DOCKER_HOST");
+    if (!string.IsNullOrEmpty(dockerHost))
+    {
+      var uri = new Uri(dockerHost);
+      using var uriConfig = new DockerClientConfiguration(uri);
+      _dockerClient = uriConfig.CreateClient();
+      return;
+    }
+    using var defaultConfig = new DockerClientConfiguration();
+    _dockerClient = defaultConfig.CreateClient();
+  }
+
+  /// <inheritdoc/>
+  public async Task<bool> CheckContainerExistsAsync(string name, CancellationToken token)
+  {
+    var containers = await _dockerClient.Containers.ListContainersAsync(new ContainersListParameters
+    {
+      All = true,
+      Filters = new Dictionary<string, IDictionary<string, bool>>
+      {
+        ["name"] = new Dictionary<string, bool>
+        {
+          [name] = true
+        }
+      }
+    }, token).ConfigureAwait(false);
+
+    return containers.Any();
+  }
+
+  /// <inheritdoc/>
+  public async Task<bool> CheckReadyAsync(CancellationToken token)
+  {
+    try
+    {
+      await _dockerClient.System.PingAsync(token).ConfigureAwait(false);
+    }
+    catch (DockerApiException)
+    {
+      return false;
+    }
+    return true;
+  }
+
+  /// <inheritdoc/>
+  public async Task CreateRegistryAsync(string name, int port, CancellationToken token, Uri? proxyUrl = null)
+  {
+    bool registryExists = await CheckContainerExistsAsync(name, token).ConfigureAwait(false);
+
+    if (registryExists)
+    {
+      return;
+    }
+    CreateContainerResponse registry;
+    try
+    {
+      await _dockerClient.Images.CreateImageAsync(new ImagesCreateParameters
+      {
+        FromImage = "registry:2"
+      }, null, new Progress<JSONMessage>()).ConfigureAwait(false);
+      registry = await _dockerClient.Containers.CreateContainerAsync(new CreateContainerParameters
+      {
+        Image = "registry:2",
+        Name = name,
+        HostConfig = new HostConfig
+        {
+          PortBindings = new Dictionary<string, IList<PortBinding>>
+          {
+            ["5000/tcp"] =
+          [
+            new() {
+              HostPort = $"{port}"
+            }
+          ]
+          },
+          RestartPolicy = new RestartPolicy
+          {
+            Name = RestartPolicyKind.Always
+          },
+          Binds =
+          [
+            $"{name}:/var/lib/registry"
+          ]
+        },
+        Env = proxyUrl != null ? new List<string>
+      {
+        $"REGISTRY_PROXY_REMOTEURL={proxyUrl}"
+      } : null
+      }).ConfigureAwait(false);
+      _ = await _dockerClient.Containers.StartContainerAsync(registry.ID, new ContainerStartParameters()).ConfigureAwait(false);
+    }
+    catch (DockerApiException)
+    {
+      throw;
+    }
+  }
+
+  /// <inheritdoc/>
+  public async Task DeleteRegistryAsync(string name, CancellationToken token)
+  {
+    string containerId = await GetContainerIdAsync(name, token).ConfigureAwait(false);
+
+    if (string.IsNullOrEmpty(containerId))
+    {
+      throw new InvalidOperationException($"Could not find registry '{name}'");
+    }
+    else
+    {
+      _ = await _dockerClient.Containers.StopContainerAsync(containerId, new ContainerStopParameters(), token).ConfigureAwait(false);
+      await _dockerClient.Containers.RemoveContainerAsync(containerId, new ContainerRemoveParameters(), token).ConfigureAwait(false);
+    }
+  }
+
+  /// <inheritdoc/>
+  public async Task<string> GetContainerIdAsync(string name, CancellationToken token)
+  {
+    var containers = await _dockerClient.Containers.ListContainersAsync(new ContainersListParameters
+    {
+      All = true,
+      Filters = new Dictionary<string, IDictionary<string, bool>>
+      {
+        ["name"] = new Dictionary<string, bool>
+        {
+          [name] = true
+        }
+      }
+    }, token).ConfigureAwait(false) ?? throw new InvalidOperationException($"Could not find container '{name}'");
+
+    return containers.FirstOrDefault()?.ID ?? string.Empty;
+  }
+}

--- a/Devantler.ContainerEngineProvisioner.Docker/GlobalSuppressions.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+// This file is used by Code Analysis to maintain SuppressMessage attributes that are applied to this project.
+// Project-level suppressions either have no target or are given a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Global suppression for CA1303")]

--- a/Devantler.ContainerEngineProvisioner.sln
+++ b/Devantler.ContainerEngineProvisioner.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Devantler.ContainerEngineProvisioner.Core", "Devantler.ContainerEngineProvisioner.Core\Devantler.ContainerEngineProvisioner.Core.csproj", "{2539BF21-CAAE-4348-9721-26A6C5636607}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Devantler.ContainerEngineProvisioner.Docker", "Devantler.ContainerEngineProvisioner.Docker\Devantler.ContainerEngineProvisioner.Docker.csproj", "{515A8D4F-C2CB-460A-A905-9B8D94C693A0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Devantler.ContainerEngineProvisioner.Docker.Tests", "Devantler.ContainerEngineProvisioner.Docker.Tests\Devantler.ContainerEngineProvisioner.Docker.Tests.csproj", "{796D9A76-F70D-4004-88C8-B9BE4EAB32F7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2539BF21-CAAE-4348-9721-26A6C5636607}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2539BF21-CAAE-4348-9721-26A6C5636607}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2539BF21-CAAE-4348-9721-26A6C5636607}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2539BF21-CAAE-4348-9721-26A6C5636607}.Release|Any CPU.Build.0 = Release|Any CPU
+		{515A8D4F-C2CB-460A-A905-9B8D94C693A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{515A8D4F-C2CB-460A-A905-9B8D94C693A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{515A8D4F-C2CB-460A-A905-9B8D94C693A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{515A8D4F-C2CB-460A-A905-9B8D94C693A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{796D9A76-F70D-4004-88C8-B9BE4EAB32F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{796D9A76-F70D-4004-88C8-B9BE4EAB32F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{796D9A76-F70D-4004-88C8-B9BE4EAB32F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{796D9A76-F70D-4004-88C8-B9BE4EAB32F7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,21 +1,40 @@
-# .NET Template
+# 🐳 .NET Container Engine Provisioner
+
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Test](https://github.com/devantler/dotnet-container-engine-provisioner/actions/workflows/test.yaml/badge.svg)](https://github.com/devantler/dotnet-container-engine-provisioner/actions/workflows/test.yaml)
+[![codecov](https://codecov.io/gh/devantler/dotnet-container-engine-provisioner/graph/badge.svg?token=RhQPb4fE7z)](https://codecov.io/gh/devantler/dotnet-container-engine-provisioner)
+
+Simple provisioners that can provision various resources in container engines.
 
 <details>
   <summary>Show/hide folder structure</summary>
 
 <!-- readme-tree start -->
+
 ```
 .
-└── .github
-    └── workflows
+├── .github
+│   └── workflows
+├── Devantler.KubernetesProvisioner.Cluster.Core
+├── Devantler.KubernetesProvisioner.Cluster.K3d
+├── Devantler.KubernetesProvisioner.Cluster.K3d.Tests
+│   ├── K3dProvisionerTests
+│   └── assets
+├── Devantler.KubernetesProvisioner.Cluster.Kind
+├── Devantler.KubernetesProvisioner.Cluster.Kind.Tests
+│   ├── KindProvisionerTests
+│   └── assets
+├── Devantler.KubernetesProvisioner.Resources.Native
+└── Devantler.KubernetesProvisioner.Resources.Native.Tests
+    ├── KubernetesResourceProvisionerTests
+    └── assets
 
-2 directories
+15 directories
 ```
+
 <!-- readme-tree end -->
 
 </details>
-
-A simple .NET template for new projects.
 
 ## Prerequisites
 
@@ -23,46 +42,25 @@ A simple .NET template for new projects.
 
 ## 🚀 Getting Started
 
-To get started, you can install the package from NuGet.
+To get started, you can install the packages from NuGet.
 
 ```bash
-dotnet add package <package-name>
+# For provisioning resources in Docker
+dotnet add package Devantler.ContainerEngineProvisioner.Docker
 ```
 
-## 📝 Usage
+## Usage
 
-### Add a solution
+To use the provisioners, all you need to do is to create and use a new instance of the provisioner.
 
-```sh
-dotnet new sln --name <name-of-solution>
-```
+```csharp
+using Devantler.ContainerEngineProvisioner.Docker;
 
-### Add a project
+var provisioner = new DockerProvisioner();
 
-```sh
-dotnet new <project-type> --output folder1/folder2/<name-of-project>
-```
+string registryName = "new_registry";
+int port = 5010;
 
-### Add project to solution
-
-```sh
-dotnet sln add folder1/folder2/<name-of-project>
-```
-
-### Building your solution
-
-```sh
-dotnet build
-```
-
-### Running a project in your solution
-
-```sh
-dotnet run folder1/folder2/<name-of-project>
-```
-
-### Testing your solution
-
-```sh
-dotnet test
+// Act
+await _provisioner.CreateRegistryAsync(registryName, port, CancellationToken.None);
 ```


### PR DESCRIPTION
This pull request adds a new Docker container engine provisioner to the project. The provisioner includes functionality to create and delete registries in the container engine, check if the container engine is ready, and get the container ID of a container in the engine. The provisioner is implemented in the `Devantler.ContainerEngineProvisioner.Docker` namespace and includes unit tests in the `Devantler.ContainerEngineProvisioner.Docker.Tests` namespace.