### PR TITLE
Refactor IContainerEngineProvisioner method signatures for CancellationToken defaults

### DIFF
--- a/Devantler.ContainerEngineProvisioner.Core/IContainerEngineProvisioner.cs
+++ b/Devantler.ContainerEngineProvisioner.Core/IContainerEngineProvisioner.cs
@@ -8,34 +8,34 @@ public interface IContainerEngineProvisioner
   /// <summary>
   /// Checks if the container engine is ready.
   /// </summary>
-  /// <param name="token"></param>
-  Task<bool> CheckReadyAsync(CancellationToken token);
+  /// <param name="cancellationToken"></param>
+  Task<bool> CheckReadyAsync(CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Creates a registry in the container engine.
   /// </summary>
   /// <param name="name"></param>
   /// <param name="port"></param>
-  /// <param name="token"></param>
   /// <param name="proxyUrl"></param>
-  Task CreateRegistryAsync(string name, int port, CancellationToken token, Uri? proxyUrl = null);
+  /// <param name="cancellationToken"></param>
+  Task CreateRegistryAsync(string name, int port, Uri? proxyUrl = default, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Deletes a registry in the container engine.
   /// </summary>
   /// <param name="name"></param>
-  /// <param name="token"></param>
-  Task DeleteRegistryAsync(string name, CancellationToken token);
+  /// <param name="cancellationToken"></param>
+  Task DeleteRegistryAsync(string name, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Gets the container ID of a container in the container engine.
   /// </summary>
   /// <param name="name"></param>
-  /// <param name="token"></param>
-  Task<string> GetContainerIdAsync(string name, CancellationToken token);
+  /// <param name="cancellationToken"></param>
+  Task<string> GetContainerIdAsync(string name, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Checks that the container exists in the container engine.
   /// </summary>
-  Task<bool> CheckContainerExistsAsync(string name, CancellationToken token);
+  Task<bool> CheckContainerExistsAsync(string name, CancellationToken cancellationToken = default);
 }

--- a/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker.Tests/DockerProvisionerTests/CreateRegistryAsyncTests.cs
@@ -1,7 +1,7 @@
 namespace Devantler.ContainerEngineProvisioner.Docker.Tests.DockerProvisionerTests;
 
 /// <summary>
-/// Unit tests for <see cref="DockerProvisioner.CreateRegistryAsync(string, int, CancellationToken, Uri?)"/> and <see cref="DockerProvisioner.DeleteRegistryAsync(string, CancellationToken)"/>.
+/// Unit tests for <see cref="DockerProvisioner.CreateRegistryAsync(string, int, Uri?, CancellationToken)"/> and <see cref="DockerProvisioner.DeleteRegistryAsync(string, CancellationToken)"/>.
 /// </summary>
 public class CreateRegistryAsyncTests
 {
@@ -17,17 +17,17 @@ public class CreateRegistryAsyncTests
     // Arrange
     string registryName = "new_registry";
     int port = 5999;
-    var token = CancellationToken.None;
+    var cancellationToken = CancellationToken.None;
 
     // Act
-    await _provisioner.CreateRegistryAsync(registryName, port, token);
+    await _provisioner.CreateRegistryAsync(registryName, port, cancellationToken: cancellationToken);
 
     // Assert
-    bool registryExists = await _provisioner.CheckContainerExistsAsync(registryName, token);
+    bool registryExists = await _provisioner.CheckContainerExistsAsync(registryName, cancellationToken: cancellationToken);
     Assert.True(registryExists);
 
     // Cleanup
-    await _provisioner.DeleteRegistryAsync(registryName, token);
+    await _provisioner.DeleteRegistryAsync(registryName, cancellationToken: cancellationToken);
   }
 
   /// <summary>
@@ -39,17 +39,17 @@ public class CreateRegistryAsyncTests
     // Arrange
     string registryName = "new_registry";
     int port = 5999;
-    var token = CancellationToken.None;
+    var cancellationToken = CancellationToken.None;
 
     // Act
-    await _provisioner.CreateRegistryAsync(registryName, port, token);
-    await _provisioner.CreateRegistryAsync(registryName, port, token);
+    await _provisioner.CreateRegistryAsync(registryName, port, cancellationToken: cancellationToken);
+    await _provisioner.CreateRegistryAsync(registryName, port, cancellationToken: cancellationToken);
 
     // Assert
-    bool registry1Exists = await _provisioner.CheckContainerExistsAsync(registryName, token);
-    await _provisioner.DeleteRegistryAsync(registryName, token);
+    bool registry1Exists = await _provisioner.CheckContainerExistsAsync(registryName, cancellationToken);
+    await _provisioner.DeleteRegistryAsync(registryName, cancellationToken);
     Assert.True(registry1Exists);
-    bool registry2Exists = await _provisioner.CheckContainerExistsAsync(registryName, token);
+    bool registry2Exists = await _provisioner.CheckContainerExistsAsync(registryName, cancellationToken);
     Assert.False(registry2Exists);
   }
 
@@ -62,17 +62,17 @@ public class CreateRegistryAsyncTests
     // Arrange
     string registryName = "new_registry";
     int port = 5999;
-    var token = CancellationToken.None;
+    var cancellationToken = CancellationToken.None;
     Uri proxyUrl = new("http://proxy:8080");
 
     // Act
-    await _provisioner.CreateRegistryAsync(registryName, port, token, proxyUrl);
+    await _provisioner.CreateRegistryAsync(registryName, port, proxyUrl, cancellationToken);
 
     // Assert
-    bool registryExists = await _provisioner.CheckContainerExistsAsync(registryName, token);
+    bool registryExists = await _provisioner.CheckContainerExistsAsync(registryName, cancellationToken);
     Assert.True(registryExists);
 
     // Cleanup
-    await _provisioner.DeleteRegistryAsync(registryName, token);
+    await _provisioner.DeleteRegistryAsync(registryName, cancellationToken);
   }
 }

--- a/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
@@ -29,7 +29,7 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
   }
 
   /// <inheritdoc/>
-  public async Task<bool> CheckContainerExistsAsync(string name, CancellationToken token)
+  public async Task<bool> CheckContainerExistsAsync(string name, CancellationToken cancellationToken = default)
   {
     var containers = await _dockerClient.Containers.ListContainersAsync(new ContainersListParameters
     {
@@ -41,17 +41,17 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
           [name] = true
         }
       }
-    }, token).ConfigureAwait(false);
+    }, cancellationToken).ConfigureAwait(false);
 
     return containers.Any();
   }
 
   /// <inheritdoc/>
-  public async Task<bool> CheckReadyAsync(CancellationToken token)
+  public async Task<bool> CheckReadyAsync(CancellationToken cancellationToken = default)
   {
     try
     {
-      await _dockerClient.System.PingAsync(token).ConfigureAwait(false);
+      await _dockerClient.System.PingAsync(cancellationToken).ConfigureAwait(false);
     }
     catch (DockerApiException)
     {
@@ -61,9 +61,9 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
   }
 
   /// <inheritdoc/>
-  public async Task CreateRegistryAsync(string name, int port, CancellationToken token, Uri? proxyUrl = null)
+  public async Task CreateRegistryAsync(string name, int port, Uri? proxyUrl = default, CancellationToken cancellationToken = default)
   {
-    bool registryExists = await CheckContainerExistsAsync(name, token).ConfigureAwait(false);
+    bool registryExists = await CheckContainerExistsAsync(name, cancellationToken).ConfigureAwait(false);
 
     if (registryExists)
     {
@@ -114,9 +114,9 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
   }
 
   /// <inheritdoc/>
-  public async Task DeleteRegistryAsync(string name, CancellationToken token)
+  public async Task DeleteRegistryAsync(string name, CancellationToken cancellationToken = default)
   {
-    string containerId = await GetContainerIdAsync(name, token).ConfigureAwait(false);
+    string containerId = await GetContainerIdAsync(name, cancellationToken).ConfigureAwait(false);
 
     if (string.IsNullOrEmpty(containerId))
     {
@@ -124,13 +124,13 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
     }
     else
     {
-      _ = await _dockerClient.Containers.StopContainerAsync(containerId, new ContainerStopParameters(), token).ConfigureAwait(false);
-      await _dockerClient.Containers.RemoveContainerAsync(containerId, new ContainerRemoveParameters(), token).ConfigureAwait(false);
+      _ = await _dockerClient.Containers.StopContainerAsync(containerId, new ContainerStopParameters(), cancellationToken).ConfigureAwait(false);
+      await _dockerClient.Containers.RemoveContainerAsync(containerId, new ContainerRemoveParameters(), cancellationToken).ConfigureAwait(false);
     }
   }
 
   /// <inheritdoc/>
-  public async Task<string> GetContainerIdAsync(string name, CancellationToken token)
+  public async Task<string> GetContainerIdAsync(string name, CancellationToken cancellationToken = default)
   {
     var containers = await _dockerClient.Containers.ListContainersAsync(new ContainersListParameters
     {
@@ -142,7 +142,7 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
           [name] = true
         }
       }
-    }, token).ConfigureAwait(false) ?? throw new InvalidOperationException($"Could not find container '{name}'");
+    }, cancellationToken).ConfigureAwait(false) ?? throw new InvalidOperationException($"Could not find container '{name}'");
 
     return containers.FirstOrDefault()?.ID ?? string.Empty;
   }


### PR DESCRIPTION
Update method signatures in IContainerEngineProvisioner to use default CancellationToken parameters, simplifying usage and improving consistency across the interface. Adjust corresponding unit tests to reflect these changes.