### PR TITLE
Fix string interpolation in DockerProvisioner to use single quotes

### DIFF
--- a/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
+++ b/Devantler.ContainerEngineProvisioner.Docker/DockerProvisioner.cs
@@ -102,7 +102,7 @@ public sealed class DockerProvisioner : IContainerEngineProvisioner
       [
         "sh",
         "-c",
-        $"echo \"{content}\" > {path}"
+        $"echo '{content}' > {path}"
       ]
     }, cancellationToken).ConfigureAwait(false);
     _ = await Client.Exec.StartAndAttachContainerExecAsync(execResponse.ID, true, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Update string interpolation in DockerProvisioner to use single quotes for content, ensuring proper handling of special characters.